### PR TITLE
Feature/bavfw release engineer tooling.part1

### DIFF
--- a/README.brd21.release.engineer.md
+++ b/README.brd21.release.engineer.md
@@ -1,0 +1,32 @@
+# Introduction
+
+The overall idea here is to make this repo a stand-alone tooling that operates
+only on the build system prepared binary package (without needing access to brd21 source tree)
+which means it needs to host its own tooling to:
+
+1. Sign plain binaries with HSM using espsecure
+2. Stitch together the binaries into an mmb brd21 ota-binary package (similar to what ota_gen.sh do for us today)
+3. Encrypt the ota-binary package using the esptool provided ota_encryption_gen.sh
+
+# TODO
+An imagined workflow looks like this
+
+1. Get and extract a prod.secure tarball from the build system
+2. call something like `prepare_signed_flasher_bundle.sh tme.sifton prod.secure <path-to-input-unsigned-tarbal> <name-of-output-signed-tarbal>`
+ the script will:
+
+ 2.1. extract the `<input-unsigned-tarbal>`
+
+ 2.2. confirm that the contents contains
+    2.2.1. the expected binaries (i.e. `tme.sifton` and `prod.secure` in the binary names)
+    2.2.2. the expected key (i.e. pub key for ota-encrypted)
+
+ 2.3. sign using HSM (prompt for pin)
+ 2.4. call a helper script to make ota-binary (i.e. an improved ota_gen.sh)
+ 2.5. call a helper script to encrypt ota-binary (using a standalone copy of `ota_encryption_gen.sh`)
+
+ 2.6. re-tar up the prepared file into `<name-of-signed-tarbal>` and clean up any intermediate files
+
+3. the `release engineer can then re-upload` the `<name-of-output-signed-tarbal>` back to S3 for further processing
+
+So download, run-script and re-upload, which is much less error prone.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# What is this branch for?
+
+We took esptool.py from upstream and applied:
+
+- A workaround to enable image signing with NitroKey HSM2
+- A way to prompt for HSM Pin instead of plaintext data in config files
+- A collection of scripts to make this branch a standalone `release engineer` tooling for MMB BRD21 `prod.secure` binary release
+  - See `README.brd21.release.engineer.md` in this repo for more details
+
+# Original Upstream README.md below
 # esptool.py
 
 A Python-based, open-source, platform-independent utility to communicate with the ROM bootloader in Espressif chips.

--- a/brd21-hsm-config.conf
+++ b/brd21-hsm-config.conf
@@ -1,0 +1,34 @@
+#
+# ref: https://blog.espressif.com/secure-signing-using-external-hsm-ebe855a2f2ef
+#
+#      Added as a a convenient starting point for MMB BRD21 Image signing
+#      using pre-prepared NitroKey HSM2 keys.
+#
+# Config file for the external Hardware Security Module
+# All of this are mandatory
+[hsm_config]
+
+#
+# PKCS11 shared object/library (pick one)
+#
+# For Linux
+pkcs11_lib = /usr/lib/x86_64-linux-gnu/opensc-pkcs11.so
+# For Mac
+# pkcs11_lib = /Library/OpenSC/lib/opensc-pkcs11.so
+
+# HSM login credentials or pin PIN
+# When set to "prompt" (recommended) the user will be prompted to enter their pin
+#
+credentials = prompt
+
+#
+# "slot", "label" and "label_pubkey" are HSM key dependent. The proper settings
+# for an HSM can be obtained by running `pkcs11-tool -O` with HSM attached)
+#
+
+# Slot number to be used
+slot = 0
+# Label of the object used to store the private key in the HSM
+label = esp32-secure-boot
+# Label of the object used to store corresponding public key in the HSM
+label_pubkey = esp32-secure-boot

--- a/espsecure/esp_hsm_sign/__init__.py
+++ b/espsecure/esp_hsm_sign/__init__.py
@@ -6,6 +6,7 @@ import binascii
 import configparser
 import os
 import sys
+from getpass import getpass
 
 try:
     import pkcs11
@@ -36,6 +37,12 @@ def read_hsm_config(configfile):
     for option in section_options:
         if not config.has_option(section, option):
             raise configparser.NoOptionError(option, section)
+
+    # Check if config.["credentials"] is set to "prompt" and prompt for HSM PIN
+    credentials_config_val = config.get(section, "credentials")
+    if credentials_config_val == "prompt":
+        hsm_pin = getpass("\nPlease enter the PIN of your HSM:\n")
+        config.set(section, "credentials", hsm_pin)
 
     return config[section]
 


### PR DESCRIPTION
# Part 1 of a multi series PR

## espsecure
- Modify especure to prompt for HSM PIN instead of plaintext pin in config file
- Add a sample hsm config file that will prompt and contains correct information for BRD21 signing

## README
- Update top level README with hints that this is a special purpose branch
- Update README with release engineer specific tooling to show where we are going with this branch

# Incoming in Part 2
- Helper scripts to build up the top level release engineer tooling